### PR TITLE
Add comprehensive Go version testing including Go 1.25

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,11 +19,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: [1.25.x]
+        go-version: [1.23.x, 1.24.x, 1.25.x]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code


### PR DESCRIPTION
- Add Go 1.23.x, 1.24.x, and 1.25.x to test matrix
- Update actions/setup-go from v2 to v5 for better compatibility
- Ensure Wire works correctly across multiple Go versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Please reference any Issue related to this Pull Request. Example: `Fixes #1`.

See
[here](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
for tips on good Pull Request description.
